### PR TITLE
fix: make Total GP respond to exclude toggles

### DIFF
--- a/src/components/GameGrid/TotalGamesPerDayRow.tsx
+++ b/src/components/GameGrid/TotalGamesPerDayRow.tsx
@@ -21,7 +21,7 @@ function TotalGamesPerDayRow({
         </td>
       ))}
       {/* Total GP */}
-      <td>{games.reduce((prev, current) => prev + current, 0)}</td>
+      <td>{calcTotalGP(games, excludedDays)}</td>
       {/* Total Off-Nights */}
       <td>{calcTotalOffNights(games, excludedDays)}</td>
     </tr>
@@ -29,9 +29,29 @@ function TotalGamesPerDayRow({
 }
 
 /**
+ * Calculate Total Number of Games Played for the week.
+ * @param games A list The number of games per day
+ * @param excludedDays The days to be ignored.
+ * @returns The number of games played in the week.
+ */
+function calcTotalGP(games: number[], excludedDays: Day[]) {
+  let total = 0;
+  // ["Fri","Tue"] => [4, 1]
+  const excludedDaysIdx = excludedDays.map((day) => DAYS.indexOf(day));
+  games.forEach((gamesPlayed, i) => {
+    const excluded = excludedDaysIdx.includes(i);
+    if (!excluded) {
+      total += gamesPlayed;
+    }
+  });
+  return total;
+}
+
+/**
  * That will be a total of a teams # of Games played
  * that week on a day where <=8 games are occurring.
- * @param games
+ * @param games A list of num games played.
+ * @returns The number of off-night games for the week.
  */
 function calcTotalOffNights(games: number[], excludedDays: Day[]) {
   let total = 0;


### PR DESCRIPTION
Take excluded days into consideration while calculating `Total GP`.

![image](https://user-images.githubusercontent.com/56380096/177000966-9790e98d-f496-42c0-9527-7aa4481eccc6.png)

This PR resolves #3 